### PR TITLE
优化电池相关代码，rtc驱动低电压时停止活动转只能usb插入唤醒 

### DIFF
--- a/keyboards/keymagichorse/kb_common/battery.c
+++ b/keyboards/keymagichorse/kb_common/battery.c
@@ -9,7 +9,6 @@
 #include "bhq.h"
 #include "analog.h"
 
-
 static uint8_t  battery_percent = 100;
 static uint16_t battery_mv      = 0;
 
@@ -23,11 +22,7 @@ static uint32_t battery_report_timer = 0;
 static uint8_t last_sample  = 0xFF;
 static uint8_t stable_count = 0;
 
-// 低电量标志：电池 ≤ BATTERY_LOW_MV 时置 true
-// 一旦置位，即使电压回升也不清除（需充电/USB插入后重新初始化）
 static bool battery_low_voltage = false;
-
-// RTC 唤醒计数器，每 N 次唤醒检查一次电池
 static uint8_t battery_rtc_wakeup_count = 0;
 
 __attribute__((weak)) void battery_percent_changed_user(uint8_t level) {}
@@ -66,55 +61,18 @@ static uint8_t battery_percent_debounce(uint8_t new_percent) {
 
     return (stable_count >= 3);
 }
+
 static void battery_percent_debounce_reset(void) {
     last_sample  = 0xFF;
     stable_count = 0;
 }
-/* ===================== 读取电池 ===================== */
 
-// ADC 读取重试次数，用于唤醒/上电后 ADC 未稳定的场景
 #ifndef BATTERY_ADC_RETRY_COUNT
 #    define BATTERY_ADC_RETRY_COUNT 3
 #endif
 
-// ADC 最小有效值，低于此值认为 ADC 未就绪或读数异常
-// 10bit 满量程 1023，100K/100K 分压下 3.0V 电池对应 ADC ≈ 465
 #ifndef BATTERY_ADC_MIN_VALID
 #    define BATTERY_ADC_MIN_VALID 50
-#endif
-
-// 使用 VREFINT 内部参考通道动态测量真实 VDDA
-// 原理: VREFINT 是一个固定 ~1.21V 的内部参考电压，
-// ADC 读它的值 = VREFINT_mV / VDDA_mV * FullScale
-// 因此 VDDA_mV = VREFINT_mV * FullScale / vrefint_adc
-#if defined(BATTERY_USE_VREFINT)
-static uint16_t battery_read_vdda_mv(void) {
-    // 使能内部参考电压通道 (TSVREFE)
-    // STM32F4xx/F1xx 的 ADCv2 需要置位 ADC->CCR 的 TSVREFE 位才能读取 VREFINT
-#    if defined(USE_ADCV2) && !defined(AT32F415)
-    adcSTM32EnableTSVREFE();
-#    endif
-
-    // VREFINT 需要一定的 settling time，唤醒后首次读取可能为 0 或极低值
-    // 通过重试来跳过无效的首次转换
-    adc_mux      vrefint_mux = TO_MUX(BATTERY_VREFINT_CHANNEL, 0);
-    int16_t      vrefint_adc = 0;
-    for (uint8_t i = 0; i < BATTERY_ADC_RETRY_COUNT; i++) {
-        vrefint_adc = adc_read(vrefint_mux);
-        if (vrefint_adc > 0) {
-            break;
-        }
-    }
-    if (vrefint_adc <= 0) {
-        // 读取失败，回退到默认 3.3V
-        return 3300;
-    }
-    uint32_t vdda_mv = ((uint32_t)BATTERY_VREFINT_MV * BATTERY_ADC_FULLSCALE) / (uint16_t)vrefint_adc;
-    // 钳位到合理范围 2.5V ~ 3.6V
-    if (vdda_mv < 2500) vdda_mv = 2500;
-    if (vdda_mv > 3600) vdda_mv = 3600;
-    return (uint16_t)vdda_mv;
-}
 #endif
 
 static uint8_t battery_read_percent(void) {
@@ -122,15 +80,13 @@ static uint8_t battery_read_percent(void) {
     if (usb_power_connected()) {
         battery_percent = 100;
         battery_mv      = BATTERY_MAX_MV;
-
         battery_has_valid_sample = 1;
         battery_percent_debounce_reset();
         battery_percent_changed_internal(100);
         return 1;
     }
 
-    // 唤醒或刚上电后 ADC 首次转换可能返回 0 或极低值
-    // 通过重试来跳过未就绪的首次转换
+    // 读取外部 ADC (电池分压)
     int16_t adc = 0;
     for (uint8_t i = 0; i < BATTERY_ADC_RETRY_COUNT; i++) {
         adc = analogReadPin(BATTERY_ADC_PIN);
@@ -138,47 +94,33 @@ static uint8_t battery_read_percent(void) {
             break;
         }
     }
-    if (adc < BATTERY_ADC_MIN_VALID || adc > 700) {
-        // ADC 未就绪或读数异常，跳过本次采样等待下次
+    if (adc < BATTERY_ADC_MIN_VALID) {
         return 0;
     }
 
-#if defined(BATTERY_USE_VREFINT)
-    // 动态测量 VDDA，消除 LDO dropout 导致的 VDDA 偏移
-    uint16_t vdda_mv = battery_read_vdda_mv();
-    uint16_t mv_div = ((uint32_t)adc * vdda_mv) / BATTERY_ADC_FULLSCALE;
-#else
-    uint16_t vdda_mv = 3300;
-    uint16_t mv_div = (adc * 3300UL) / 1023; // 10bit
-#endif
+    // 读取 VREFINT
+    adcSTM32EnableTSVREFE();
+    adc_mux vrefint_mux = TO_MUX(BATTERY_VREFINT_CHANNEL, 0);
+    int16_t vrefint_adc = adc_read(vrefint_mux);
 
-    battery_mv = (uint16_t)((uint32_t)mv_div * (BAT_R_UPPER + BAT_R_LOWER) / BAT_R_LOWER);
+    // 打印原始值
+    km_printf("adc:%d vrefint:%d\n", adc, vrefint_adc);
 
-    // 低电量检测：一旦触发就锁定，防止 ADC 波动反复触发
-    if (battery_mv <= BATTERY_LOW_MV) {
-        battery_low_voltage = true;
-    }
-
-    // /* 电压 → 百分比 */
+    // VDDA = VREFINT_mV * FullScale / vrefint_adc
+    // adc_read 返回 10bit，BATTERY_ADC_FULLSCALE=1023，BATTERY_VREFINT_MV=1210
+    uint32_t vdda_mv = ((uint32_t)BATTERY_VREFINT_MV * BATTERY_ADC_FULLSCALE) / (uint16_t)vrefint_adc;
+    // 分压后的电压
+    uint32_t mv_div = (uint32_t)adc * vdda_mv / BATTERY_ADC_FULLSCALE;
+    // 电池电压
+    battery_mv = (uint16_t)(mv_div * (BAT_R_UPPER + BAT_R_LOWER) / BAT_R_LOWER);
     uint8_t new_percent = calculate_battery_percentage(battery_mv);
+    km_printf("vdda:%d bat:%d pct:%d\n", vdda_mv, battery_mv, new_percent);
 
-    km_printf("1 adc:%d vdda:%d mv_div:%d bat mv:%d\n", adc, vdda_mv, mv_div, battery_mv);
-
-    /* 5% 一档 */
-    new_percent = ((new_percent + 2) / 5) * 5;
-    if (new_percent > 100) new_percent = 100;
-
-    /* 只允许下降 */
-    if (battery_has_valid_sample && new_percent > battery_percent) {
-        new_percent = battery_percent;
-    }
-
-    // /* 消抖判断 */
     if (battery_percent_debounce(new_percent)) {
         battery_percent_changed_internal(new_percent);
         battery_percent          = new_percent;
         battery_has_valid_sample = 1;
-        km_printf("battery stable: %dmV -> %d%\n", battery_mv, battery_percent);
+        km_printf("battery stable: %dmV -> %d%%\n", battery_mv, battery_percent);
         return 1;
     }
 
@@ -188,7 +130,6 @@ static uint8_t battery_read_percent(void) {
 void battery_task(void) {
     if (timer_elapsed32(battery_sample_timer) > 500) {
         battery_sample_timer = timer_read32();
-
         if (battery_is_read_enabled) {
             battery_read_percent();
         }
@@ -199,7 +140,7 @@ void battery_task(void) {
     if (battery_ble_update_en && timer_elapsed32(battery_report_timer) > 2500) {
         battery_report_timer = timer_read32();
         if (usb_power_connected()) {
-            return ;
+            return;
         }
         battery_percent_update_wireless();
     }
@@ -209,11 +150,7 @@ void battery_init(void) {
     battery_percent_debounce_reset();
     battery_low_voltage      = false;
     battery_rtc_wakeup_count = 0;
-
-#if defined(BATTERY_USE_VREFINT) && defined(USE_ADCV2) && !defined(AT32F415)
-    // 提前使能内部参考电压通道，确保第一次读取 VREFINT 时已就绪
     adcSTM32EnableTSVREFE();
-#endif
 }
 
 void battery_reset_timer(void) {
@@ -248,54 +185,19 @@ bool battery_is_low_voltage(void) {
     return battery_low_voltage;
 }
 
-// RTC 唤醒循环中使用的轻量级电池电压检查
-// 每 BATTERY_RTC_CHECK_INTERVAL 次唤醒执行一次 ADC 读取
-// 返回 true 表示电压正常，false 表示电压过低应禁用 RTC 唤醒
 bool battery_rtc_check_voltage(void) {
-    // USB 连接时直接返回正常（USB 供电场景不走 RTC 唤醒）
     if (usb_power_connected()) {
         battery_low_voltage      = false;
         battery_rtc_wakeup_count = 0;
         return true;
     }
-
-    // 已标记为低电量，直接返回 false
     if (battery_low_voltage) {
         return false;
     }
-
-    // 每 N 次唤醒才检查一次，减少 RTC 唤醒循环中的功耗
     battery_rtc_wakeup_count++;
     if (battery_rtc_wakeup_count < BATTERY_RTC_CHECK_INTERVAL) {
         return true;
     }
     battery_rtc_wakeup_count = 0;
-
-    // 读取电池 ADC（此时 ADC 已由 lpm_hal_init/ec_init 初始化）
-    int16_t adc = 0;
-    for (uint8_t i = 0; i < BATTERY_ADC_RETRY_COUNT; i++) {
-        adc = analogReadPin(BATTERY_ADC_PIN);
-        if (adc >= BATTERY_ADC_MIN_VALID) {
-            break;
-        }
-    }
-    if (adc < BATTERY_ADC_MIN_VALID) {
-        // ADC 未就绪，不判定为低电量，继续 RTC 唤醒
-        return true;
-    }
-
-#if defined(BATTERY_USE_VREFINT)
-    uint16_t vdda_mv = battery_read_vdda_mv();
-    uint16_t mv_div  = ((uint32_t)adc * vdda_mv) / BATTERY_ADC_FULLSCALE;
-#else
-    uint16_t mv_div = (adc * 3300UL) / 1023;
-#endif
-    uint16_t mv = (uint16_t)((uint32_t)mv_div * (BAT_R_UPPER + BAT_R_LOWER) / BAT_R_LOWER);
-
-    if (mv <= BATTERY_LOW_MV) {
-        battery_low_voltage = true;
-        return false;
-    }
-
     return true;
 }

--- a/keyboards/keymagichorse/kb_common/battery.c
+++ b/keyboards/keymagichorse/kb_common/battery.c
@@ -10,8 +10,8 @@
 #include "analog.h"
 
 
-uint8_t  battery_percent = 100;
-uint16_t battery_mv      = 0;
+static uint8_t  battery_percent = 100;
+static uint16_t battery_mv      = 0;
 
 static uint8_t battery_has_valid_sample = 0;
 static uint8_t battery_is_read_enabled  = 1;
@@ -22,6 +22,13 @@ static uint32_t battery_report_timer = 0;
 
 static uint8_t last_sample  = 0xFF;
 static uint8_t stable_count = 0;
+
+// 低电量标志：电池 ≤ BATTERY_LOW_MV 时置 true
+// 一旦置位，即使电压回升也不清除（需充电/USB插入后重新初始化）
+static bool battery_low_voltage = false;
+
+// RTC 唤醒计数器，每 N 次唤醒检查一次电池
+static uint8_t battery_rtc_wakeup_count = 0;
 
 __attribute__((weak)) void battery_percent_changed_user(uint8_t level) {}
 __attribute__((weak)) void battery_percent_changed_kb(uint8_t level) {}
@@ -65,6 +72,51 @@ static void battery_percent_debounce_reset(void) {
 }
 /* ===================== 读取电池 ===================== */
 
+// ADC 读取重试次数，用于唤醒/上电后 ADC 未稳定的场景
+#ifndef BATTERY_ADC_RETRY_COUNT
+#    define BATTERY_ADC_RETRY_COUNT 3
+#endif
+
+// ADC 最小有效值，低于此值认为 ADC 未就绪或读数异常
+// 10bit 满量程 1023，100K/100K 分压下 3.0V 电池对应 ADC ≈ 465
+#ifndef BATTERY_ADC_MIN_VALID
+#    define BATTERY_ADC_MIN_VALID 50
+#endif
+
+// 使用 VREFINT 内部参考通道动态测量真实 VDDA
+// 原理: VREFINT 是一个固定 ~1.21V 的内部参考电压，
+// ADC 读它的值 = VREFINT_mV / VDDA_mV * FullScale
+// 因此 VDDA_mV = VREFINT_mV * FullScale / vrefint_adc
+#if defined(BATTERY_USE_VREFINT)
+static uint16_t battery_read_vdda_mv(void) {
+    // 使能内部参考电压通道 (TSVREFE)
+    // STM32F4xx/F1xx 的 ADCv2 需要置位 ADC->CCR 的 TSVREFE 位才能读取 VREFINT
+#    if defined(USE_ADCV2) && !defined(AT32F415)
+    adcSTM32EnableTSVREFE();
+#    endif
+
+    // VREFINT 需要一定的 settling time，唤醒后首次读取可能为 0 或极低值
+    // 通过重试来跳过无效的首次转换
+    adc_mux      vrefint_mux = TO_MUX(BATTERY_VREFINT_CHANNEL, 0);
+    int16_t      vrefint_adc = 0;
+    for (uint8_t i = 0; i < BATTERY_ADC_RETRY_COUNT; i++) {
+        vrefint_adc = adc_read(vrefint_mux);
+        if (vrefint_adc > 0) {
+            break;
+        }
+    }
+    if (vrefint_adc <= 0) {
+        // 读取失败，回退到默认 3.3V
+        return 3300;
+    }
+    uint32_t vdda_mv = ((uint32_t)BATTERY_VREFINT_MV * BATTERY_ADC_FULLSCALE) / (uint16_t)vrefint_adc;
+    // 钳位到合理范围 2.5V ~ 3.6V
+    if (vdda_mv < 2500) vdda_mv = 2500;
+    if (vdda_mv > 3600) vdda_mv = 3600;
+    return (uint16_t)vdda_mv;
+}
+#endif
+
 static uint8_t battery_read_percent(void) {
     /* USB 供电直接认为 100% */
     if (usb_power_connected()) {
@@ -77,19 +129,40 @@ static uint8_t battery_read_percent(void) {
         return 1;
     }
 
-    int16_t adc = analogReadPin(BATTERY_ADC_PIN);
-    if(adc > 700)
-    {
+    // 唤醒或刚上电后 ADC 首次转换可能返回 0 或极低值
+    // 通过重试来跳过未就绪的首次转换
+    int16_t adc = 0;
+    for (uint8_t i = 0; i < BATTERY_ADC_RETRY_COUNT; i++) {
+        adc = analogReadPin(BATTERY_ADC_PIN);
+        if (adc >= BATTERY_ADC_MIN_VALID) {
+            break;
+        }
+    }
+    if (adc < BATTERY_ADC_MIN_VALID || adc > 700) {
+        // ADC 未就绪或读数异常，跳过本次采样等待下次
         return 0;
     }
+
+#if defined(BATTERY_USE_VREFINT)
+    // 动态测量 VDDA，消除 LDO dropout 导致的 VDDA 偏移
+    uint16_t vdda_mv = battery_read_vdda_mv();
+    uint16_t mv_div = ((uint32_t)adc * vdda_mv) / BATTERY_ADC_FULLSCALE;
+#else
+    uint16_t vdda_mv = 3300;
     uint16_t mv_div = (adc * 3300UL) / 1023; // 10bit
+#endif
 
     battery_mv = (uint16_t)((uint32_t)mv_div * (BAT_R_UPPER + BAT_R_LOWER) / BAT_R_LOWER);
+
+    // 低电量检测：一旦触发就锁定，防止 ADC 波动反复触发
+    if (battery_mv <= BATTERY_LOW_MV) {
+        battery_low_voltage = true;
+    }
 
     // /* 电压 → 百分比 */
     uint8_t new_percent = calculate_battery_percentage(battery_mv);
 
-    km_printf("1 adc:%d mv_div:%d bat mv:%d\n", adc, mv_div, battery_mv);
+    km_printf("1 adc:%d vdda:%d mv_div:%d bat mv:%d\n", adc, vdda_mv, mv_div, battery_mv);
 
     /* 5% 一档 */
     new_percent = ((new_percent + 2) / 5) * 5;
@@ -134,13 +207,20 @@ void battery_task(void) {
 
 void battery_init(void) {
     battery_percent_debounce_reset();
+    battery_low_voltage      = false;
+    battery_rtc_wakeup_count = 0;
+
+#if defined(BATTERY_USE_VREFINT) && defined(USE_ADCV2) && !defined(AT32F415)
+    // 提前使能内部参考电压通道，确保第一次读取 VREFINT 时已就绪
+    adcSTM32EnableTSVREFE();
+#endif
 }
 
 void battery_reset_timer(void) {
     battery_report_timer = timer_read32();
 }
 
-uint8_t battery_driver_sample_percent(void) {
+uint8_t battery_get_percent(void) {
     return battery_has_valid_sample ? battery_percent : 0xFF;
 }
 
@@ -158,4 +238,64 @@ void battery_enable_ble_update(void) {
 
 void battery_disable_ble_update(void) {
     battery_ble_update_en = 0;
+}
+
+uint16_t battery_get_mv(void) {
+    return battery_mv;
+}
+
+bool battery_is_low_voltage(void) {
+    return battery_low_voltage;
+}
+
+// RTC 唤醒循环中使用的轻量级电池电压检查
+// 每 BATTERY_RTC_CHECK_INTERVAL 次唤醒执行一次 ADC 读取
+// 返回 true 表示电压正常，false 表示电压过低应禁用 RTC 唤醒
+bool battery_rtc_check_voltage(void) {
+    // USB 连接时直接返回正常（USB 供电场景不走 RTC 唤醒）
+    if (usb_power_connected()) {
+        battery_low_voltage      = false;
+        battery_rtc_wakeup_count = 0;
+        return true;
+    }
+
+    // 已标记为低电量，直接返回 false
+    if (battery_low_voltage) {
+        return false;
+    }
+
+    // 每 N 次唤醒才检查一次，减少 RTC 唤醒循环中的功耗
+    battery_rtc_wakeup_count++;
+    if (battery_rtc_wakeup_count < BATTERY_RTC_CHECK_INTERVAL) {
+        return true;
+    }
+    battery_rtc_wakeup_count = 0;
+
+    // 读取电池 ADC（此时 ADC 已由 lpm_hal_init/ec_init 初始化）
+    int16_t adc = 0;
+    for (uint8_t i = 0; i < BATTERY_ADC_RETRY_COUNT; i++) {
+        adc = analogReadPin(BATTERY_ADC_PIN);
+        if (adc >= BATTERY_ADC_MIN_VALID) {
+            break;
+        }
+    }
+    if (adc < BATTERY_ADC_MIN_VALID) {
+        // ADC 未就绪，不判定为低电量，继续 RTC 唤醒
+        return true;
+    }
+
+#if defined(BATTERY_USE_VREFINT)
+    uint16_t vdda_mv = battery_read_vdda_mv();
+    uint16_t mv_div  = ((uint32_t)adc * vdda_mv) / BATTERY_ADC_FULLSCALE;
+#else
+    uint16_t mv_div = (adc * 3300UL) / 1023;
+#endif
+    uint16_t mv = (uint16_t)((uint32_t)mv_div * (BAT_R_UPPER + BAT_R_LOWER) / BAT_R_LOWER);
+
+    if (mv <= BATTERY_LOW_MV) {
+        battery_low_voltage = true;
+        return false;
+    }
+
+    return true;
 }

--- a/keyboards/keymagichorse/kb_common/battery.h
+++ b/keyboards/keymagichorse/kb_common/battery.h
@@ -47,13 +47,58 @@
 #endif
 // ------------------------ 电池电压读取的引脚 ------------------------
 
+// ------------------------ VREFINT 校准配置 ------------------------
+// 使用 STM32 内部参考电压通道(VREFINT)动态测量 VDDA，
+// 消除 LDO dropout 导致 VDDA 偏离 3.3V 时的 ADC 误差。
+// STM32F4xx: VREFINT 通道为 17，标称 1.21V
+// STM32F1xx: VREFINT 通道为 17，标称 1.20V
+#if !defined(BATTERY_USE_VREFINT) && (defined(STM32F4XX) || defined(STM32F1XX))
+#    define BATTERY_USE_VREFINT
+#endif
+
+// VREFINT 标称电压 (mV)，STM32F4xx=1210, STM32F1xx=1200
+#ifndef BATTERY_VREFINT_MV
+#    ifdef STM32F4XX
+#        define BATTERY_VREFINT_MV    1210
+#    else
+#        define BATTERY_VREFINT_MV    1200
+#    endif
+#endif
+
+// VREFINT 通道号
+#ifndef BATTERY_VREFINT_CHANNEL
+#    define BATTERY_VREFINT_CHANNEL  ADC_CHANNEL_VREFINT
+#endif
+
+// ADC 满量程值 (10bit=1023, 12bit=4095)
+#ifndef BATTERY_ADC_FULLSCALE
+#    define BATTERY_ADC_FULLSCALE    1023
+#endif
+// ------------------------ VREFINT 校准配置 ------------------------
+
+// ------------------------ 低电量保护配置 ------------------------
+// 当电池电压低于此阈值 (mV) 时，禁用 RTC 周期唤醒，只保留 USB 插入唤醒
+// 3.3V LDO 在此电压以下已无法稳压，ADC 读数不可靠，EC 矩阵可能误触发
+#ifndef BATTERY_LOW_MV
+#    define BATTERY_LOW_MV     3400
+#endif
+
+// RTC 唤醒循环中每 N 次唤醒检查一次电池电压
+#ifndef BATTERY_RTC_CHECK_INTERVAL
+#    define BATTERY_RTC_CHECK_INTERVAL  10
+#endif
+// ------------------------ 低电量保护配置 ------------------------
 
 
 
 void battery_init(void);
 void battery_task(void);
 void battery_reset_timer(void);
-uint8_t battery_driver_sample_percent(void);
+
+// 获取电池百分比 (0~100)，未采样返回 0xFF
+uint8_t battery_get_percent(void);
+// 兼容旧代码的别名
+#define battery_driver_sample_percent() battery_get_percent()
 
 void battery_percent_changed_user(uint8_t level);
 void battery_percent_changed_kb(uint8_t level);
@@ -63,3 +108,13 @@ void battery_enable_read(void);
 void battery_disable_read(void);
 void battery_enable_ble_update(void);
 void battery_disable_ble_update(void);
+
+// 获取电池电压 (mV)，由 battery_task 更新
+uint16_t battery_get_mv(void);
+
+// 低电量查询：返回 true 表示电池电压过低，应禁用 RTC 唤醒
+bool battery_is_low_voltage(void);
+
+// RTC 唤醒循环中使用的轻量级电池检查
+// 返回 true 表示电压正常，false 表示电压过低
+bool battery_rtc_check_voltage(void);

--- a/keyboards/keymagichorse/kb_common/bhq_common.c
+++ b/keyboards/keymagichorse/kb_common/bhq_common.c
@@ -185,6 +185,21 @@ bool process_record_bhq(uint16_t keycode, keyrecord_t *record) {
             }
             return true;
         }
+#if defined(KB_CHECK_BATTERY_ENABLED)
+        case BAT_INFO:
+        {
+            if(record->event.pressed)
+            {
+                // 输出电池信息: Bat: 85% 3950mV
+                char buf[24];
+                int  len = snprintf(buf, sizeof(buf), "Bat: %d%% %dmV\n", battery_get_percent(), battery_get_mv());
+                if (len > 0) {
+                    send_string(buf);
+                }
+            }
+            return false;
+        }
+#endif
     }
     return true;
 }

--- a/keyboards/keymagichorse/kb_common/bhq_common.h
+++ b/keyboards/keymagichorse/kb_common/bhq_common.h
@@ -55,9 +55,14 @@
 #ifndef BLE_RESET
 #   define BLE_RESET    QK_USER_28      
 #endif
- // 关闭蓝牙连接
+// 关闭蓝牙连接
 #ifndef BLE_OFF
 #   define BLE_OFF      QK_USER_29       
+#endif
+
+// 输出电池信息（百分比 + 电压 mV）
+#ifndef BAT_INFO
+#   define BAT_INFO     QK_USER_30
 #endif
 
 void bhq_set_lowbat_led(bool on);

--- a/keyboards/keymagichorse/kb_common/lpm_core.c
+++ b/keyboards/keymagichorse/kb_common/lpm_core.c
@@ -310,6 +310,9 @@ static void lpm_wake_restore(void) {
 
 #if defined(KB_CHECK_BATTERY_ENABLED)
     battery_enable_read();
+    // 唤醒后重新初始化电池状态，清除低电量标志
+    // （如果是 USB 插入唤醒，此时已转为 USB 供电，电池电压不再受限）
+    battery_init();
 #endif
 
     lpm_device_power_open();
@@ -448,6 +451,19 @@ static void lpm_sleep_with_rtc_wakeup(void) {
     if (!lpm_sleep_prepare()) {
         return;  // USB 已连接，不进入休眠
     }
+
+    // 低电量检查：电池过低时禁用 RTC 周期唤醒，只保留 USB 插入唤醒
+    // 此时不设 RTC 唤醒，直接进入 STOP 模式等待 USB 中断唤醒
+#if defined(KB_CHECK_BATTERY_ENABLED) && defined(LPM_EC_MATRIX)
+    if (battery_is_low_voltage()) {
+        // 不设 RTC 唤醒，仅依赖 USB 插入引脚事件唤醒
+        palEnableLineEvent(USB_POWER_SENSE_PIN, PAL_EVENT_MODE_RISING_EDGE);
+        lpm_chip_enter_stop_mode();
+        lpm_wake_restore();
+        return;
+    }
+#endif
+
     lpm_chip_enter_stop_mode();
 
     while (1) {
@@ -455,6 +471,23 @@ static void lpm_sleep_with_rtc_wakeup(void) {
         lpm_hal_init();
 #endif
         lpm_chip_rtc_wakeup_clear();
+
+#if defined(KB_CHECK_BATTERY_ENABLED) && defined(LPM_EC_MATRIX)
+        // RTC 唤醒后检查电池电压，每 N 次唤醒检查一次
+        // 电压过低时退出 RTC 唤醒循环，转为仅 USB 唤醒
+        if (!battery_rtc_check_voltage()) {
+            // 电池电压过低，禁用 RTC 唤醒
+            // 只做必要的休眠准备，不设 RTC 唤醒
+            // USB 插入检测引脚已在 lpm_sleep_prepare() 中配置
+            palEnableLineEvent(USB_POWER_SENSE_PIN, PAL_EVENT_MODE_RISING_EDGE);
+#    ifdef BHQ_IQR_PIN
+            gpio_set_pin_input_low(BHQ_IQR_PIN);
+            palEnableLineEvent(BHQ_IQR_PIN, PAL_EVENT_MODE_RISING_EDGE);
+#    endif
+            lpm_chip_enter_stop_mode();
+            break;
+        }
+#endif
 
         if (lowpower_matrix_task()) {
 #ifdef LPM_EC_MATRIX


### PR DESCRIPTION
优化电池相关代码，rtc驱动低电压时停止活动转只能usb插入唤醒 